### PR TITLE
feat(install): 添加对rime-wubi中lua脚本的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
-fcitx5-master
+# Local cargo config (created by dev-install.sh for libximecore patch)
+.cargo/config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,3 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2.3"
 
-# Local development override — remove after pushing libximecore
-[patch."https://github.com/ximeiorg/libximecore"]
-librime = { path = "../libximecore/crates/librime" }
-xime-config = { path = "../libximecore/crates/xime-config" }
-xime-setup-lib = { path = "../libximecore/crates/xime-setup" }

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -11,6 +11,21 @@ LIBXIMECORE="${PROJECT_ROOT}/../libximecore"
 
 echo "Installing xime-wayland for development to ${HOME}/.local"
 
+# Ensure .cargo/config.toml exists with local libximecore patch
+CARGO_CONF="${PROJECT_ROOT}/.cargo/config.toml"
+if [ ! -f "${CARGO_CONF}" ]; then
+    mkdir -p "${PROJECT_ROOT}/.cargo"
+    cat > "${CARGO_CONF}" << 'EOF'
+# Local development override — use local libximecore checkout.
+# Remove this file to use git dependencies (CI, release builds).
+[patch."https://github.com/ximeiorg/libximecore"]
+librime = { path = "../libximecore/crates/librime" }
+xime-config = { path = "../libximecore/crates/xime-config" }
+xime-setup-lib = { path = "../libximecore/crates/xime-setup" }
+EOF
+    echo "Created ${CARGO_CONF} with local libximecore patch"
+fi
+
 # Stop existing xime processes to refresh
 echo "Stopping existing xime processes..."
 pkill -9 xime-daemon 2>/dev/null || true
@@ -62,6 +77,11 @@ if [ -d "${PROJECT_ROOT}/rime-wubi" ]; then
     cp -r "${PROJECT_ROOT}/rime-wubi"/*.schema.yaml \
           "${PROJECT_ROOT}/rime-wubi"/*.dict.yaml \
           "${PROJECT_ROOT}/rime-wubi"/*.lua "${RIMEDIR}/" 2>/dev/null || true
+    # Copy lua/ subdirectory (uuid, date_translator, etc.)
+    if [ -d "${PROJECT_ROOT}/rime-wubi/lua" ]; then
+        cp -r "${PROJECT_ROOT}/rime-wubi/lua" "${RIMEDIR}/"
+        echo "Installed lua scripts to ${RIMEDIR}/lua"
+    fi
     cp "${PROJECT_ROOT}/rime-wubi"/default.custom.yaml "${RIMEDIR}/" 2>/dev/null || true
     cp "${PROJECT_ROOT}/rime-wubi"/xime.custom.yaml "${RIMEDIR}/" 2>/dev/null || true
     echo "Installed rime-wubi schemas to ${RIMEDIR}"

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,14 @@ if [ -d "${PROJECT_ROOT}/rime-wubi" ]; then
     for file in "${PROJECT_ROOT}/rime-wubi"/*.schema.yaml "${PROJECT_ROOT}/rime-wubi"/*.dict.yaml "${PROJECT_ROOT}/rime-wubi"/*.lua; do
         [ -f "$file" ] && install -m644 "$file" "${DATADIR}/xime/rime-data/"
     done
+    # Copy lua/ subdirectory (uuid, date_translator, etc.)
+    if [ -d "${PROJECT_ROOT}/rime-wubi/lua" ]; then
+        install -d "${DATADIR}/xime/rime-data/lua"
+        for lua_file in "${PROJECT_ROOT}/rime-wubi/lua"/*.lua; do
+            [ -f "$lua_file" ] && install -m644 "$lua_file" "${DATADIR}/xime/rime-data/lua/"
+        done
+        echo "Installed lua scripts to ${DATADIR}/xime/rime-data/lua"
+    fi
     install -m644 "${PROJECT_ROOT}/rime-wubi"/default.custom.yaml "${DATADIR}/xime/rime-data/" 2>/dev/null || true
     install -m644 "${PROJECT_ROOT}/rime-wubi"/xime.custom.yaml "${DATADIR}/xime/rime-data/" 2>/dev/null || true
     echo "Installed rime-wubi schemas to ${DATADIR}/xime/rime-data"


### PR DESCRIPTION
- 在安装脚本中添加复制lua子目录的功能
- 支持安装uuid、date_translator等lua脚本到目标目录

refactor(dev): 优化本地开发配置管理

- 移除Cargo.toml中的本地patch配置
- 创建dev-install.sh脚本来动态生成.cargo/config.toml
- 使用脚本方式管理本地libximecore依赖覆盖
- 更新.gitignore以包含新的cargo配置文件路径

chore(rime-wubi): 更新子项目提交版本

- 将rime-wubi子项目更新到最新提交版本